### PR TITLE
Added Zeppelin editor runtime

### DIFF
--- a/zeppelin/Dockerfile
+++ b/zeppelin/Dockerfile
@@ -1,0 +1,39 @@
+# Dockerfile
+
+# Base runtime image is the latest maintenance release from Cloudera
+FROM docker.repository.cloudera.com/cdsw/ml-runtime-workbench-python3.7-standard:2021.09.1-b5
+
+# Define zeppelin home location
+ENV ZEPPELIN_HOME=/opt/zeppelin
+
+# Download and unpack Zeppelin.
+RUN mkdir -p "$ZEPPELIN_HOME" && \
+      curl -sL https://dlcdn.apache.org/zeppelin/zeppelin-0.10.1/zeppelin-0.10.1-bin-all.tgz | tar -xz -C "$ZEPPELIN_HOME" --strip-components=1
+
+
+# Add launch script and zeppling server parameters
+ADD run-zeppelin.sh $ZEPPELIN_HOME/run-zeppelin.sh
+ADD zeppelin-site.xml $ZEPPELIN_HOME/conf
+
+
+# User cdsw will be running everything on pod initialization, and needs permissions
+RUN chown -RL cdsw:cdsw $ZEPPELIN_HOME && chmod u+x $ZEPPELIN_HOME/run-zeppelin.sh 
+
+
+# Create symlink to editor launch script
+RUN ln -sf $ZEPPELIN_HOME/run-zeppelin.sh /usr/local/bin/ml-runtime-editor
+
+
+# Override Runtime label and environment variables metadata
+ENV ML_RUNTIME_EDITION="Community runtime with Apache Zeppling 0.10.1" \
+    ML_RUNTIME_SHORT_VERSION="1.0" \
+    ML_RUNTIME_MAINTENANCE_VERSION=1 \
+    ML_RUNTIME_DESCRIPTION="Includes Apache Zeppelin (v0.10.1) as the default editor, along with all base librarires and interpreters."\
+    ML_RUNTIME_EDITOR="Zeppelin"
+ENV ML_RUNTIME_FULL_VERSION="${ML_RUNTIME_SHORT_VERSION}.${ML_RUNTIME_MAINTENANCE_VERSION}"
+LABEL com.cloudera.ml.runtime.edition=$ML_RUNTIME_EDITION \
+      com.cloudera.ml.runtime.full-version=$ML_RUNTIME_FULL_VERSION \
+      com.cloudera.ml.runtime.short-version=$ML_RUNTIME_SHORT_VERSION \
+      com.cloudera.ml.runtime.maintenance-version=$ML_RUNTIME_MAINTENANCE_VERSION \
+      com.cloudera.ml.runtime.description=$ML_RUNTIME_DESCRIPTION \
+      com.cloudera.ml.runtime.editor=$ML_RUNTIME_EDITOR

--- a/zeppelin/run-zeppelin.sh
+++ b/zeppelin/run-zeppelin.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Launch Zeppelin process in the foreground (using zeppelin-daemon.sh will NOT work)
+$ZEPPELIN_HOME/bin/zeppelin.sh --config $ZEPPELIN_HOME/conf

--- a/zeppelin/zeppelin-site.xml
+++ b/zeppelin/zeppelin-site.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<configuration>
+
+<property>
+  <name>zeppelin.server.addr</name>
+  <value>127.0.0.1</value>
+  <description>Server binding address</description>
+</property>
+
+<property>
+  <name>zeppelin.server.port</name>
+  <value>8090</value>
+  <description>Server port.</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.dir</name>
+  <value>/home/cdsw</value>
+  <description>path or URI for notebook persist</description>
+</property>
+
+<property>
+  <name>zeppelin.run.mode</name>
+  <value>local</value>
+  <description>'auto|local|k8s|docker'</description>
+</property>
+
+</configuration>


### PR DESCRIPTION
I've tested building this Zeppelin editor Docker image with CML on public cloud. The UI comes up in a session and at a minimum Python interpreter works fine.  